### PR TITLE
Get the module functional in terraform 0.12 + ready for Kibana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+es-cleanup*.zip

--- a/es-cleanup.py
+++ b/es-cleanup.py
@@ -191,10 +191,10 @@ def skip_index(index_name, skip_list):
     for pattern in skip_list:
         if pattern.endswith('*'):
             if index_name.startswith(pattern[:-1]):
-                return true
+                return True
         else:
             if index_name == pattern:
-                return true
+                return True
 
 if __name__ == '__main__':
     event = {

--- a/es-cleanup.py
+++ b/es-cleanup.py
@@ -168,9 +168,8 @@ def lambda_handler(event, context):
         days=int(es.cfg["delete_after"]))
     for index in es.get_indices():
         print("Found index: {}".format(index["index"]))
-        if index["index"] in es.cfg["skip_index"]:
 
-            # ignore .kibana index
+        if skip_index(index["index"], es.cfg["skip_index"]):
             continue
 
         idx_split = index["index"].rsplit("-",
@@ -188,6 +187,14 @@ def lambda_handler(event, context):
         else:
             print("Index {} name {} did not match pattern {}".format(index["index"], idx_name, es.cfg["index"]))
 
+def skip_index(index_name, skip_list):
+    for pattern in skip_list:
+        if pattern.endswith('*'):
+            if index_name.startswith(pattern[:-1]):
+                return true
+        else:
+            if index_name == pattern:
+                return true
 
 if __name__ == '__main__':
     event = {

--- a/lambda.tf
+++ b/lambda.tf
@@ -37,8 +37,8 @@ resource "aws_lambda_function" "es_cleanup" {
   # This will be a code block with empty lists if we don't create a securitygroup and the subnet_ids are empty.
   # When these lists are empty it will deploy the lambda without VPC support.
   vpc_config {
-    subnet_ids         = ["${var.subnet_ids}"]
-    security_group_ids = ["${compact(concat(local.sg_ids, var.security_group_ids))}"]
+    subnet_ids         = var.subnet_ids
+    security_group_ids = compact(concat(local.sg_ids, var.security_group_ids))
   }
 }
 

--- a/sg.tf
+++ b/sg.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "lambda" {
   count       = "${length(var.subnet_ids) > 0 ? 1 : 0}"
   name        = "${var.prefix}lambda_cleanup_to_elasticsearch${var.suffix}"
   description = "${var.prefix}lambda_cleanup_to_elasticsearch${var.suffix}"
-  vpc_id      = "${data.aws_subnet.selected.vpc_id}"
+  vpc_id      = "${data.aws_subnet.selected[0].vpc_id}"
 
 
   egress {

--- a/variables.tf
+++ b/variables.tf
@@ -59,13 +59,13 @@ variable "python_version" {
 
 variable "subnet_ids" {
   description = "Subnet IDs you want to deploy the lambda in. Only fill this in if you want to deploy your Lambda function inside a VPC."
-  type        = list()
+  type        = list(string)
   default     = []
 }
 
 variable "security_group_ids" {
   description = "Addiational Security Ids To add."
-  type        = list()
+  type        = list(string)
   default     = []
 }
 


### PR DESCRIPTION
Fixed a bunch of errors, see commit messages.

This is hell-a-lot of a pull request, but it is everything I needed to get this module in a functional state.

First of all, without hashing or versioning the `filename` of the `aws_lambda_function` you will never be able to update the package once you update its code.

Then the package and python code was deleting vital Kibana indices.
It is _not enough_ to just exclude `.kibana`.
Read more here: https://www.elastic.co/guide/en/kibana/current/upgrade-migrations.html

You must exclude all indices starting with `.kibana*`. Therefore I added a small feature that extends the `skip_index` attribute to act on a wildcard pattern.
Now if you specify `.kibana*` on `skip_index` all indices that start with `.kibana` in their name will be exempt from deletion.

That is important, because this morning all my Kibana dashboards were gone.